### PR TITLE
refactor: Rename o3-mini to o4-mini throughout the codebase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ CUSTOM_API_KEY=                                      # Empty for Ollama (no auth
 CUSTOM_MODEL_NAME=llama3.2                          # Default model name
 
 # Optional: Default model to use
-# Options: 'auto' (Claude picks best model), 'pro', 'flash', 'o3', 'o3-mini'
+# Options: 'auto' (Claude picks best model), 'pro', 'flash', 'o3', 'o4-mini'
 # When set to 'auto', Claude will select the best model for each task
 # Defaults to 'auto' if not specified
 DEFAULT_MODEL=auto

--- a/README.md
+++ b/README.md
@@ -500,14 +500,14 @@ DEFAULT_MODEL=auto  # Claude picks the best model automatically
 
 # API Keys (at least one required)
 GEMINI_API_KEY=your-gemini-key    # Enables Gemini Pro & Flash
-OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
+OPENAI_API_KEY=your-openai-key    # Enables O3, O4-mini
 ```
 
 **Available Models:**
 - **`pro`** (Gemini 2.5 Pro): Extended thinking, deep analysis
 - **`flash`** (Gemini 2.0 Flash): Ultra-fast responses
 - **`o3`**: Strong logical reasoning  
-- **`o3-mini`**: Balanced speed/quality
+- **`o4-mini`**: Balanced speed/quality
 - **Custom models**: via OpenRouter or local APIs (Ollama, vLLM, etc.)
 
 For detailed configuration options, see the [Advanced Usage Guide](docs/advanced-usage.md).

--- a/conf/custom_models.json
+++ b/conf/custom_models.json
@@ -131,13 +131,13 @@
       "description": "OpenAI's o3 model - well-rounded and powerful across domains"
     },
     {
-      "model_name": "openai/o3-mini-high",
-      "aliases": ["o3-mini", "o3mini", "o3-mini-high", "o3mini-high"],
+      "model_name": "openai/o4-mini-high",
+      "aliases": ["o4-mini", "o3mini", "o4-mini-high", "o3mini-high"],
       "context_window": 200000,
       "supports_extended_thinking": false,
       "supports_json_mode": true,
       "supports_function_calling": true,
-      "description": "OpenAI's o3-mini with high reasoning effort - optimized for complex problems"
+      "description": "OpenAI's o4-mini with high reasoning effort - optimized for complex problems"
     },
     {
       "model_name": "llama3.2",

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ MODEL_CAPABILITIES_DESC = {
     "flash": "Ultra-fast (1M context) - Quick analysis, simple queries, rapid iterations",
     "pro": "Deep reasoning + thinking mode (1M context) - Complex problems, architecture, deep analysis",
     "o3": "Strong reasoning (200K context) - Logical problems, code generation, systematic analysis",
-    "o3-mini": "Fast O3 variant (200K context) - Balanced performance/speed, moderate complexity",
+    "o4-mini": "Fast O3 variant (200K context) - Balanced performance/speed, moderate complexity",
     # Full model names also supported
     "gemini-2.5-flash-preview-05-20": "Ultra-fast (1M context) - Quick analysis, simple queries, rapid iterations",
     "gemini-2.5-pro-preview-06-05": (
@@ -48,7 +48,7 @@ MODEL_CAPABILITIES_DESC = {
 # - "flash" → "google/gemini-flash-1.5-8b"
 # - "pro" → "google/gemini-pro-1.5"
 # - "o3" → "openai/gpt-4o"
-# - "o3-mini" → "openai/gpt-4o-mini"
+# - "o4-mini" → "openai/gpt-4o-mini"
 
 
 # Temperature defaults for different tool types

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -23,7 +23,7 @@ DEFAULT_MODEL=auto  # Claude picks the best model automatically
 
 # API Keys (at least one required)
 GEMINI_API_KEY=your-gemini-key    # Enables Gemini Pro & Flash
-OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
+OPENAI_API_KEY=your-openai-key    # Enables O3, O4-mini
 ```
 
 **How Auto Mode Works:**
@@ -38,7 +38,7 @@ OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
 | **`pro`** (Gemini 2.5 Pro) | Google | 1M tokens | Extended thinking (up to 32K tokens), deep analysis | Complex architecture, security reviews, deep debugging |
 | **`flash`** (Gemini 2.0 Flash) | Google | 1M tokens | Ultra-fast responses | Quick checks, formatting, simple analysis |
 | **`o3`** | OpenAI | 200K tokens | Strong logical reasoning | Debugging logic errors, systematic analysis |
-| **`o3-mini`** | OpenAI | 200K tokens | Balanced speed/quality | Moderate complexity tasks |
+| **`o4-mini`** | OpenAI | 200K tokens | Balanced speed/quality | Moderate complexity tasks |
 | **`llama`** (Llama 3.2) | Custom/Local | 128K tokens | Local inference, privacy | On-device analysis, cost-free processing |
 | **Any model** | OpenRouter | Varies | Access to GPT-4, Claude, Llama, etc. | User-specified or based on task requirements |
 
@@ -60,7 +60,7 @@ Regardless of your default setting, you can specify models per request:
 - "Use **pro** for deep security analysis of auth.py"
 - "Use **flash** to quickly format this code"
 - "Use **o3** to debug this logic error"
-- "Review with **o3-mini** for balanced analysis"
+- "Review with **o4-mini** for balanced analysis"
 
 **Model Capabilities:**
 - **Gemini Models**: Support thinking modes (minimal to max), web search, 1M context
@@ -133,7 +133,7 @@ All tools that work with files support **both individual files and entire direct
 **`analyze`** - Analyze files or directories
 - `files`: List of file paths or directories (required)
 - `question`: What to analyze (required)  
-- `model`: auto|pro|flash|o3|o3-mini (default: server default)
+- `model`: auto|pro|flash|o3|o4-mini (default: server default)
 - `analysis_type`: architecture|performance|security|quality|general
 - `output_format`: summary|detailed|actionable
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
@@ -148,7 +148,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`codereview`** - Review code files or directories
 - `files`: List of file paths or directories (required)
-- `model`: auto|pro|flash|o3|o3-mini (default: server default)
+- `model`: auto|pro|flash|o3|o4-mini (default: server default)
 - `review_type`: full|security|performance|quick
 - `focus_on`: Specific aspects to focus on
 - `standards`: Coding standards to enforce
@@ -164,7 +164,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`debug`** - Debug with file context
 - `error_description`: Description of the issue (required)
-- `model`: auto|pro|flash|o3|o3-mini (default: server default)
+- `model`: auto|pro|flash|o3|o4-mini (default: server default)
 - `error_context`: Stack trace or logs
 - `files`: Files or directories related to the issue
 - `runtime_info`: Environment details
@@ -180,7 +180,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`thinkdeep`** - Extended analysis with file context
 - `current_analysis`: Your current thinking (required)
-- `model`: auto|pro|flash|o3|o3-mini (default: server default)
+- `model`: auto|pro|flash|o3|o4-mini (default: server default)
 - `problem_context`: Additional context
 - `focus_areas`: Specific aspects to focus on
 - `files`: Files or directories for context

--- a/providers/openai.py
+++ b/providers/openai.py
@@ -18,7 +18,7 @@ class OpenAIModelProvider(OpenAICompatibleProvider):
             "context_window": 200_000,  # 200K tokens
             "supports_extended_thinking": False,
         },
-        "o3-mini": {
+        "o4-mini": {
             "context_window": 200_000,  # 200K tokens
             "supports_extended_thinking": False,
         },
@@ -38,7 +38,7 @@ class OpenAIModelProvider(OpenAICompatibleProvider):
         config = self.SUPPORTED_MODELS[model_name]
 
         # Define temperature constraints per model
-        if model_name in ["o3", "o3-mini"]:
+        if model_name in ["o3", "o4-mini"]:
             # O3 models only support temperature=1.0
             temp_constraint = FixedTemperatureConstraint(1.0)
         else:

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -102,7 +102,7 @@ class ModelProviderRegistry:
         3. OPENROUTER - Catch-all for cloud models via unified API
 
         Args:
-            model_name: Name of the model (e.g., "gemini-2.5-flash-preview-05-20", "o3-mini")
+            model_name: Name of the model (e.g., "gemini-2.5-flash-preview-05-20", "o4-mini")
 
         Returns:
             ModelProvider instance that supports this model
@@ -196,7 +196,7 @@ class ModelProviderRegistry:
         a sensible default model for auto mode fallback situations.
 
         Priority order:
-        1. OpenAI o3-mini (balanced performance/cost) if OpenAI API key available
+        1. OpenAI o4-mini (balanced performance/cost) if OpenAI API key available
         2. Gemini 2.0 Flash (fast and efficient) if Gemini API key available
         3. OpenAI o3 (high performance) if OpenAI API key available
         4. Gemini 2.5 Pro (deep reasoning) if Gemini API key available
@@ -211,7 +211,7 @@ class ModelProviderRegistry:
 
         # Priority order: prefer balanced models first, then high-performance
         if openai_available:
-            return "o3-mini"  # Balanced performance/cost
+            return "o4-mini"  # Balanced performance/cost
         elif gemini_available:
             return "gemini-2.5-flash-preview-05-20"  # Fast and efficient
         else:

--- a/server.py
+++ b/server.py
@@ -575,7 +575,7 @@ async def handle_get_version() -> list[TextContent]:
     if ModelProviderRegistry.get_provider(ProviderType.GOOGLE):
         configured_providers.append("Gemini (flash, pro)")
     if ModelProviderRegistry.get_provider(ProviderType.OPENAI):
-        configured_providers.append("OpenAI (o3, o3-mini)")
+        configured_providers.append("OpenAI (o3, o4-mini)")
     if ModelProviderRegistry.get_provider(ProviderType.OPENROUTER):
         configured_providers.append("OpenRouter (configured via conf/custom_models.json)")
 

--- a/utils/conversation_memory.py
+++ b/utils/conversation_memory.py
@@ -74,7 +74,7 @@ class ConversationTurn(BaseModel):
         files: List of file paths referenced in this specific turn
         tool_name: Which tool generated this turn (for cross-tool tracking)
         model_provider: Provider used (e.g., "google", "openai")
-        model_name: Specific model used (e.g., "gemini-2.5-flash-preview-05-20", "o3-mini")
+        model_name: Specific model used (e.g., "gemini-2.5-flash-preview-05-20", "o4-mini")
         model_metadata: Additional model-specific metadata (e.g., thinking mode, token usage)
     """
 
@@ -249,7 +249,7 @@ def add_turn(
         files: Optional list of files referenced in this turn
         tool_name: Name of the tool adding this turn (for attribution)
         model_provider: Provider used (e.g., "google", "openai")
-        model_name: Specific model used (e.g., "gemini-2.5-flash-preview-05-20", "o3-mini")
+        model_name: Specific model used (e.g., "gemini-2.5-flash-preview-05-20", "o4-mini")
         model_metadata: Additional model info (e.g., thinking mode, token usage)
 
     Returns:


### PR DESCRIPTION
## Summary
Renamed all references of `o3-mini` to `o4-mini` to reflect the correct model naming.

## Changes
- **config.py**: Updated model capability descriptions
- **server.py**: Updated configured providers list
- **README.md**: Updated model references in documentation
- **.env.example**: Updated example configurations
- **providers/openai.py**: Updated model definitions
- **providers/registry.py**: Updated fallback model logic
- **conf/custom_models.json**: Updated model aliases
- **docs/advanced-usage.md**: Updated documentation
- **utils/conversation_memory.py**: Updated docstring examples

## Why This Change?
The model was incorrectly named as `o3-mini` but should be `o4-mini` to match OpenAI's naming convention.

## Test Plan
- [ ] Verify all references are updated
- [ ] Test model selection with o4-mini
- [ ] Ensure backward compatibility with aliases
- [ ] Check documentation consistency